### PR TITLE
fix: only log & send base error message

### DIFF
--- a/logmiddlware.go
+++ b/logmiddlware.go
@@ -79,7 +79,17 @@ func (w *LoggingResponseWriter) Log(status int, duration time.Duration, bytes in
 	)
 }
 
-func (w *LoggingResponseWriter) LogError(status int, msg string) {
+func (w *LoggingResponseWriter) LogError(status int, err error) {
+	msg := err.Error()
+	// unwrap error and find the msg at the bottom error
+	for {
+		if e := errors.Unwrap(err); e != nil {
+			msg = e.Error()
+			err = e
+		} else {
+			break
+		}
+	}
 	w.Log(status, 0, 0, msg)
 	w.status = status
 	if w.bytes == 0 {


### PR DESCRIPTION
Most (all?) errors that occur during traversal get wrapped in traversal- related errors so they look like "block not found" or "could not reify" when they may just be something like the client closing the connection prematurely.

So instead, let's unwrap the errors to find the base one and just send that and hopefully it's more informative. If it is a "block not found", or other traversal-related error then that'll be the base.