### PR TITLE
fix: remove duplicate error message string

### DIFF
--- a/carstream.go
+++ b/carstream.go
@@ -41,7 +41,7 @@ func StreamCar(
 	}
 
 	if err := traversal.CheckPath(datamodel.ParsePath(request.Path), lastPath); err != nil {
-		logger.Warnf("failed to traverse full requested path: %s", err)
+		logger.Warn(err)
 	}
 
 	return nil


### PR DESCRIPTION
the string in this error message is already present in the error string it prints afterward