### PR TITLE
fix: set up mux before serve to avoid race

### DIFF
--- a/frisbii.go
+++ b/frisbii.go
@@ -52,6 +52,7 @@ func NewFrisbiiServer(
 		lsys:        lsys,
 		httpOptions: httpOptions,
 		listener:    listener,
+		mux:         http.NewServeMux(),
 	}, nil
 }
 
@@ -60,7 +61,6 @@ func (fs *FrisbiiServer) Addr() net.Addr {
 }
 
 func (fs *FrisbiiServer) Serve() error {
-	fs.mux = http.NewServeMux()
 	fs.mux.Handle("/ipfs/", NewHttpIpfs(fs.ctx, fs.lsys, fs.httpOptions...))
 	fs.mux.Handle("/", http.NotFoundHandler())
 	server := &http.Server{


### PR DESCRIPTION
in main() we Serve() in a goroutine and then move on to call SetIndexerProvider which assumes a mux already exists, this can cause a race